### PR TITLE
Fix equality check for different use cases of Principals

### DIFF
--- a/aws_policy_equivalence.go
+++ b/aws_policy_equivalence.go
@@ -209,24 +209,27 @@ func (statement *awsPolicyStatement) equals(other *awsPolicyStatement) bool {
 }
 
 func mapPrincipalsEqual(ours, theirs interface{}) bool {
-	ourPrincipalMap, ok := ours.(map[string]interface{})
-	if !ok {
-		return false
-	}
-
-	theirPrincipalMap, ok := theirs.(map[string]interface{})
-	if !ok {
-		return false
-	}
+	ourPrincipalMap, oursOk := ours.(map[string]interface{})
+	theirPrincipalMap, theirsOk := theirs.(map[string]interface{})
 
 	oursNormalized := make(map[string]awsStringSet)
-	for key, val := range ourPrincipalMap {
-		oursNormalized[key] = newAWSStringSet(val)
+	if oursOk {
+		for key, val := range ourPrincipalMap {
+			var tmp = newAWSStringSet(val)
+			if len(tmp) > 0 {
+				oursNormalized[key] = tmp
+			}
+		}
 	}
 
 	theirsNormalized := make(map[string]awsStringSet)
-	for key, val := range theirPrincipalMap {
-		theirsNormalized[key] = newAWSStringSet(val)
+	if theirsOk {
+		for key, val := range theirPrincipalMap {
+			var tmp = newAWSStringSet(val)
+			if len(tmp) > 0 {
+				theirsNormalized[key] = newAWSStringSet(val)
+			}
+		}
 	}
 
 	for key, ours := range oursNormalized {
@@ -353,6 +356,9 @@ func newAWSStringSet(members interface{}) awsStringSet {
 	}
 
 	if multiple, ok := members.([]interface{}); ok {
+		if len(multiple) == 0 {
+			return awsStringSet{}
+		}
 		actions := make([]string, len(multiple))
 		for i, action := range multiple {
 			actions[i] = action.(string)

--- a/aws_policy_equivalence_test.go
+++ b/aws_policy_equivalence_test.go
@@ -162,13 +162,42 @@ func TestPolicyEquivalence(t *testing.T) {
 			policy1:    policyTest20a,
 			policy2:    policyTest20b,
 			equivalent: true,
-		},
+    },
+    
 		{
 			name:       "Single Statement vs []Statement",
 			policy1:    policyTest21a,
 			policy2:    policyTest21b,
 			equivalent: true,
-		},
+    },
+    
+    {
+			name:       "Empty Principal set",
+			policy1:    policyTest22a,
+			policy2:    policyTest22b,
+			equivalent: true,
+    },
+
+    {
+			name:       "Empty Principals sets of different types have the same effect",
+			policy1:    policyTest23a,
+			policy2:    policyTest23b,
+			equivalent: true,
+    },
+
+    {
+			name:       "Empty Principal and missing Principal have the same effect",
+			policy1:    policyTest24a,
+			policy2:    policyTest24b,
+			equivalent: true,
+    },
+
+    {
+			name:       "Principal with empty sets and missing Principal have the same effect",
+			policy1:    policyTest25a,
+			policy2:    policyTest25b,
+			equivalent: true,
+    },
 	}
 
 	for _, tc := range cases {
@@ -916,6 +945,105 @@ const policyTest21b = `{
       "Principal": {
         "Service": "spotfleet.amazonaws.com"
       }
+    }
+  ]
+}`
+
+const policyTest22a = `{
+  "Version": "2012-10-17",
+  "Statement":
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {},
+      "Action": "sts:AssumeRole"
+    }
+}`
+
+const policyTest22b = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Action": ["sts:AssumeRole"],
+      "Effect": "allow",
+      "Principal": {
+        "Service": []
+      }
+    }
+  ]
+}`
+
+const policyTest23a = `{
+  "Version": "2012-10-17",
+  "Statement":
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": []
+      },
+      "Action": "sts:AssumeRole"
+    }
+}`
+
+const policyTest23b = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Action": ["sts:AssumeRole"],
+      "Effect": "allow",
+      "Principal": {
+        "AWS": []
+      }
+    }
+  ]
+}`
+
+const policyTest24a = `{
+  "Version": "2012-10-17",
+  "Statement":
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {},
+      "Action": "sts:AssumeRole"
+    }
+}`
+
+const policyTest24b = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Action": ["sts:AssumeRole"],
+      "Effect": "allow"
+    }
+  ]
+}`
+
+const policyTest25a = `{
+  "Version": "2012-10-17",
+  "Statement":
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [],
+        "AWS": []
+      },
+      "Action": "sts:AssumeRole"
+    }
+}`
+
+const policyTest25b = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Action": ["sts:AssumeRole"],
+      "Effect": "allow"
     }
   ]
 }`


### PR DESCRIPTION
This PR ensures that syntactically different representations of empty respectively missing Principals, which are semantically equal, match. This caused Terraform to unnecessarily update aws_iam_role resources' assume_role_policy attribute due to syntactic differences.