### PR TITLE
Add go.mod and go.sum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/jen20/awspolicyequivalence
+
+require (
+	github.com/aws/aws-sdk-go v1.15.22
+	github.com/hashicorp/errwrap v1.0.0
+	github.com/mitchellh/mapstructure v1.0.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/aws/aws-sdk-go v1.15.22 h1:oBDjhvhppuHcEzchKrAB2tnt8nENQG47dGiC1865tqA=
+github.com/aws/aws-sdk-go v1.15.22/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
+github.com/go-ini/ini v1.25.4/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/mitchellh/mapstructure v1.0.0 h1:vVpGvMXJPqSDh2VYHF7gsfQj8Ncx+Xw5Y1KHeTRY+7I=
+github.com/mitchellh/mapstructure v1.0.0/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=


### PR DESCRIPTION
Support for [Go modules](https://github.com/golang/go/wiki/Modules).

Created on Go 1.11 via:
* `go mod init`
* `go test ./...`

```
$ go mod init
go: creating new go.mod: module github.com/jen20/awspolicyequivalence
$ go test ./...
go: finding github.com/hashicorp/errwrap v1.0.0
go: finding github.com/mitchellh/mapstructure v1.0.0
go: finding github.com/aws/aws-sdk-go/aws/arn latest
go: finding github.com/aws/aws-sdk-go/aws latest
go: downloading github.com/hashicorp/errwrap v1.0.0
go: downloading github.com/mitchellh/mapstructure v1.0.0
ok  	github.com/jen20/awspolicyequivalence	0.026s
```