### PR TITLE
Replace aws/aws-sdk-go/arn package with internal ARN parsing

### DIFF
--- a/aws_policy_equivalence.go
+++ b/aws_policy_equivalence.go
@@ -9,11 +9,11 @@ package awspolicy
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"regexp"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/hashicorp/errwrap"
 	"github.com/mitchellh/mapstructure"
 )
@@ -276,16 +276,16 @@ func stringPrincipalsEqual(ours, theirs interface{}) bool {
 	awsAccountIDRegex := regexp.MustCompile(`^[0-9]{12}$`)
 
 	if awsAccountIDRegex.MatchString(ourPrincipal) {
-		if theirArn, err := arn.Parse(theirPrincipal); err == nil {
-			if theirArn.Service == "iam" && theirArn.Resource == "root" && theirArn.AccountID == ourPrincipal {
+		if theirArn, err := parseAwsArnString(theirPrincipal); err == nil {
+			if theirArn.service == "iam" && theirArn.resource == "root" && theirArn.account == ourPrincipal {
 				return true
 			}
 		}
 	}
 
 	if awsAccountIDRegex.MatchString(theirPrincipal) {
-		if ourArn, err := arn.Parse(ourPrincipal); err == nil {
-			if ourArn.Service == "iam" && ourArn.Resource == "root" && ourArn.AccountID == theirPrincipal {
+		if ourArn, err := parseAwsArnString(ourPrincipal); err == nil {
+			if ourArn.service == "iam" && ourArn.resource == "root" && ourArn.account == theirPrincipal {
 				return true
 			}
 		}
@@ -434,4 +434,33 @@ func (ours awsPrincipalStringSet) equals(theirs awsPrincipalStringSet) bool {
 	}
 
 	return true
+}
+
+// awsArn describes an Amazon Resource Name
+// More information: http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+type awsArn struct {
+	account   string
+	partition string
+	region    string
+	resource  string
+	service   string
+}
+
+// parseAwsArnString converts a string into an awsArn
+// Expects string in form of: arn:PARTITION:SERVICE:REGION:ACCOUNT:RESOURCE
+func parseAwsArnString(arn string) (awsArn, error) {
+	if !strings.HasPrefix(arn, "arn:") {
+		return awsArn{}, fmt.Errorf("expected arn: prefix, received: %s", arn)
+	}
+	arnParts := strings.SplitN(arn, ":", 6)
+	if len(arnParts) != 6 {
+		return awsArn{}, fmt.Errorf("expected 6 colon delimited sections, received: %s", arn)
+	}
+	return awsArn{
+		account:   arnParts[4],
+		partition: arnParts[1],
+		region:    arnParts[3],
+		resource:  arnParts[5],
+		service:   arnParts[2],
+	}, nil
 }

--- a/aws_policy_equivalence_test.go
+++ b/aws_policy_equivalence_test.go
@@ -8,6 +8,55 @@ import (
 	"testing"
 )
 
+func TestParseAwsArnString(t *testing.T) {
+	cases := []struct {
+		input string
+		arn   awsArn
+		err   bool
+	}{
+		{
+			input: "invalid:prefix",
+			err:   true,
+		},
+		{
+			input: "arn:missing:sections",
+			err:   true,
+		},
+		{
+			input: "arn:aws:ec2:us-west-2:123456789012:instance/i-01234567",
+			arn: awsArn{
+				partition: "aws",
+				service:   "ec2",
+				region:    "us-west-2",
+				account:   "123456789012",
+				resource:  "instance/i-01234567",
+			},
+		},
+		{
+			input: "arn:aws:iam::123456789012:root",
+			arn: awsArn{
+				partition: "aws",
+				service:   "iam",
+				region:    "",
+				account:   "123456789012",
+				resource:  "root",
+			},
+		},
+	}
+	for _, tc := range cases {
+		arn, err := parseAwsArnString(tc.input)
+		if !tc.err && err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		if tc.err && err == nil {
+			t.Fatal("Expected error, none produced")
+		}
+		if tc.arn != arn {
+			t.Errorf("Expected %q to parse as %v, but got %v", tc.input, tc.arn, arn)
+		}
+	}
+}
+
 func TestPolicyEquivalence(t *testing.T) {
 	cases := []struct {
 		name       string


### PR DESCRIPTION
```
$ go test ./...
ok  	_/Users/bflad/src/github.com/jen20/awspolicyequivalence	0.025s
```