### PR TITLE
No panic on invalid Statement.Resource type

### DIFF
--- a/aws_policy_equivalence.go
+++ b/aws_policy_equivalence.go
@@ -383,6 +383,10 @@ func newAWSStringSet(members interface{}) awsStringSet {
 		}
 		actions := make([]string, len(multiple))
 		for i, action := range multiple {
+			if _, ok := action.(string); !ok {
+				return nil
+			}
+
 			actions[i] = action.(string)
 		}
 		return awsStringSet(actions)
@@ -396,6 +400,10 @@ func newAWSPrincipalStringSet(members interface{}) awsPrincipalStringSet {
 }
 
 func (actions awsStringSet) equals(other awsStringSet) bool {
+	if actions == nil || other == nil {
+		return false
+	}
+
 	if len(actions) != len(other) {
 		return false
 	}

--- a/aws_policy_equivalence_test.go
+++ b/aws_policy_equivalence_test.go
@@ -272,6 +272,32 @@ func TestPolicyEquivalence(t *testing.T) {
 			policy2:    policyTest29b,
 			equivalent: true,
 		},
+		{
+			name:       "Missing Statement",
+			policy1:    policyTest30,
+			policy2:    policyTest30,
+			equivalent: false,
+			err:        true,
+		},
+		{
+			name:       "Incorrect Statement type",
+			policy1:    policyTest31,
+			policy2:    policyTest31,
+			equivalent: false,
+			err:        true,
+		},
+		{
+			name:       "Incorrect single Resource type",
+			policy1:    policyTest32,
+			policy2:    policyTest32,
+			equivalent: false,
+		},
+		{
+			name:       "Incorrect multiple Resource type",
+			policy1:    policyTest33,
+			policy2:    policyTest33,
+			equivalent: false,
+		},
 	}
 
 	for _, tc := range cases {
@@ -1244,6 +1270,43 @@ const policyTest29b = `{
           "arn:PARTITION:iam::999999999999:root"
         ]
       }
+    }
+  ]
+}`
+
+const policyTest30 = `{
+  "Version": "2012-10-17"
+}`
+
+const policyTest31 = `{
+  "Version": "2012-10-17",
+  "Statement": 42
+}`
+
+const policyTest32 = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "statement1",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": 42
+    }
+  ]
+}`
+
+const policyTest33 = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "statement1",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": [42]
     }
   ]
 }`


### PR DESCRIPTION
Fixes https://github.com/jen20/awspolicyequivalence/issues/8.

```console
$ go test
PASS
ok  	github.com/jen20/awspolicyequivalence	0.004s
```

Without the `if _, ok := action.(string); !ok` code the test panics:

```console
$ go test
--- FAIL: TestPolicyEquivalence (0.00s)
panic: interface conversion: interface {} is float64, not string [recovered]
	panic: interface conversion: interface {} is float64, not string

goroutine 8 [running]:
testing.tRunner.func1(0xc00008c200)
	/usr/local/go/src/testing/testing.go:874 +0x3a3
panic(0x558bc0, 0xc00013b800)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/jen20/awspolicyequivalence.newAWSStringSet(0x547cc0, 0xc0001395c0, 0x0, 0x6c2788, 0x0)
	/home/kit/wrk/src/github.com/jen20/awspolicyequivalence/aws_policy_equivalence.go:386 +0x212
github.com/jen20/awspolicyequivalence.(*awsPolicyStatement).equals(0xc00012bcb0, 0xc00012bd40, 0x0)
	/home/kit/wrk/src/github.com/jen20/awspolicyequivalence/aws_policy_equivalence.go:175 +0x299
github.com/jen20/awspolicyequivalence.(*awsPolicyDocument).equals(0xc000128b00, 0xc000128b80, 0x0)
	/home/kit/wrk/src/github.com/jen20/awspolicyequivalence/aws_policy_equivalence.go:114 +0xea
github.com/jen20/awspolicyequivalence.PoliciesAreEquivalent(0x592f2c, 0xbc, 0x592f2c, 0xbc, 0x0, 0x0, 0x0)
	/home/kit/wrk/src/github.com/jen20/awspolicyequivalence/aws_policy_equivalence.go:50 +0x361
github.com/jen20/awspolicyequivalence.TestPolicyEquivalence(0xc00008c200)
	/home/kit/wrk/src/github.com/jen20/awspolicyequivalence/aws_policy_equivalence_test.go:304 +0x115
testing.tRunner(0xc00008c200, 0x5953e8)
	/usr/local/go/src/testing/testing.go:909 +0xc9
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:960 +0x350
exit status 2
FAIL	github.com/jen20/awspolicyequivalence	0.005s
```